### PR TITLE
Added semicolon for ACF support

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -11,6 +11,6 @@ component {
 			apiUrl    = 'https://www.google.com/recaptcha/api/siteverify',
 			secretKey = "",
 			publicKey = ""
-		}
+		};
 	}
 }


### PR DESCRIPTION
ACF will throw an error if the semicolon is missing.