### PR TITLE
don't use variables scoped http result

### DIFF
--- a/models/RecaptchaService.cfc
+++ b/models/RecaptchaService.cfc
@@ -59,12 +59,13 @@ component singleton accessors="true"{
 	 * @remoteIP The remote IP
 	 */
 	struct function httpSend( required string response, string remoteIP ){
+		var result = 0; // definitely assigned by cfhttp statement
 
-		 cfhttp(
+		cfhttp(
 			method  = "POST",
 			url 	= config.apiUrl,
 			timeout = 10,
-			result = "result"
+			result = "local.result"
 		) {
 			cfhttpparam( type = "header",    name="Content-Type", value = "application/x-www-form-urlencoded" );
 			cfhttpparam( type = "formfield", name="response", 	 value = arguments.response );

--- a/models/RecaptchaService.cfc
+++ b/models/RecaptchaService.cfc
@@ -59,8 +59,6 @@ component singleton accessors="true"{
 	 * @remoteIP The remote IP
 	 */
 	struct function httpSend( required string response, string remoteIP ){
-		var result = 0; // definitely assigned by cfhttp statement
-
 		cfhttp(
 			method  = "POST",
 			url 	= config.apiUrl,
@@ -73,7 +71,7 @@ component singleton accessors="true"{
 			cfhttpparam( type = "formfield", name="secret",		 value = getSecretKey() );
 		}
 
-		return result;
+		return local.result;
 	}
 
 	/*********************************** PRIVATE ***********************************/


### PR DESCRIPTION
use local scope for http result to prevent inadvertent cross thread sharing of the singleton variables scope.