### PR TITLE
Add theme data attribute as widget argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ In any form you wish to add the reCaptcha widget use the following:
 	view="widget",
 	module="recaptcha",
 	args={
-		size = "normal" // normal or compact
+		size = "normal", // normal or compact
+		theme = "light" // light or dark
 	}
 )#
 </div>
 ```
 
-The only argument the widget receives is the `size` of the captcha:
-- `normal`
-- `compact`
+The widget view can receive the following arguments:
+- `size` ('normal' or 'compact') Optional. The size of the widget.
+- `theme` ('dark or 'light') Optional. The color theme of the widget.
 
 ### Validation
 

--- a/views/widget.cfm
+++ b/views/widget.cfm
@@ -1,5 +1,6 @@
 <cfscript>
 	param name="args.size" default="normal"; // normal, or compact
+	param name="args.theme default="light"; // light or dark
 </cfscript>
 <cfoutput>
 	<cfif isnull( prc.recaptcha_inited )>
@@ -10,5 +11,6 @@
 		class="g-recaptcha"
 		data-sitekey="#getModuleSettings( "recaptcha" ).publicKey#"
 		data-size="#args.size#"
+		data-theme="#args.theme#
 	></div>
 </cfoutput>


### PR DESCRIPTION
Google's reCAPTCHA supports a `data-theme` attribute to render the reCAPTCHA check in light or dark mode. This PR adds that ability and updates the readme accordingly.